### PR TITLE
Ensure tasks are ran only once per execution

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,7 @@ tasks:
       echo "✅ ALL TOOLS INSTALLED"
 
   tools:go-licenses:
+    run: once
     vars:
       VERSION: v1.6.0
     cmd: >
@@ -29,6 +30,7 @@ tasks:
       && go install github.com/google/go-licenses@{{.VERSION}}
 
   tools:golangci-lint:
+    run: once
     vars:
       VERSION: v1.64.6
     status:
@@ -41,6 +43,7 @@ tasks:
       && go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{.VERSION}}
 
   tools:rancher-machine:
+    run: once
     vars:
       VERSION: v0.15.0-rancher126
     status:
@@ -65,6 +68,7 @@ tasks:
       echo "✅ ALL DEPENDENCIES INSTALLED"
 
   dependencies:node:
+    run: once
     method: checksum
     sources:
       - package.json
@@ -73,6 +77,7 @@ tasks:
       yarn install --frozen-lockfile
 
   dependencies:go:
+    run: once
     method: checksum
     sources:
       - go.mod
@@ -96,12 +101,14 @@ tasks:
       echo "✅ ALL LINTERS PASSED"
 
   lint:commits:
+    run: once
     deps:
       - dependencies:node
     cmd: >
       yarn exec commitlint -- --from=main --verbose
 
   lint:go:
+    run: once
     deps:
       - tools:golangci-lint
       - dependencies:go
@@ -109,6 +116,7 @@ tasks:
       ./tools/golangci-lint run -v
 
   lint:go-licenses:
+    run: once
     deps:
       - tools:go-licenses
       - dependencies:go
@@ -118,6 +126,7 @@ tasks:
       --disallowed_types=forbidden,restricted,reciprocal,unknown
 
   lint:markdown:
+    run: once
     deps:
       - dependencies:node
     cmd: >
@@ -135,6 +144,7 @@ tasks:
       echo "✅ PROJECT BUILT"
 
   build:docker-machine-driver-pve:
+    run: once
     deps:
       - dependencies:go
     sources:


### PR DESCRIPTION
# Description

Without `run: once` tasks will be executed multiple times if they are used as dependencies in multiple places + they might run in parallel. This can be observed when running `task lint --force`, where task `dependencies:go` will (sometimes) fail because both instances will try to modify `vendor` directory.

## How Has This Been Tested?

```
task lint --force
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
