### PR TITLE
Create normal/prerelease releases instead of drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
-          gh release create "${GITHUB_REF_NAME}" \
+          RELEASE_FLAGS=""
+          && if [[ "${GITHUB_REF_NAME}" == *"-rc"* ]]; then RELEASE_FLAGS="--prerelease"; fi
+          && gh release create "${GITHUB_REF_NAME}" \
             --repo="${GITHUB_REPOSITORY}" \
             --title="${GITHUB_REF_NAME}" \
-            --draft \
+            $RELEASE_FLAGS \
             --generate-notes \
             ./release_artifacts/*
       - name: Update GitHub Pages Helm repo index


### PR DESCRIPTION
# Description

* Until now, GitHub Action created draft releases that had to be manually published.
* Now that we also update index of Helm Charts via GitHub Pages, it breaks the chart index as Helm Chart stored as release artifact is not available until it is published.
* This PR changes behaviour of releases, and
  * creates a "prerelease" for tags with `-rc`,
  * creates a normal release otherwise.

## How Has This Been Tested?

In forked repo.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
