### PR TITLE
Include licenses of node dependencies in licenses.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,26 @@ jobs:
           git config user.name 'github-actions[bot]'
           && git config user.email 'github-actions[bot]@users.noreply.github.com'
       # Set-up build environment
-      - uses: azure/setup-helm@v4.3.0
-      - uses: actions/setup-go@v5
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@v1.6.0
-      - name: Pull dependencies
+      - name: Pull Go dependencies
         run: go mod vendor
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - name: Pull Node dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install go-licenses
+        run: >
+          mkdir -p ./tools
+          && export GOBIN="$(realpath ./tools)"
+          && go install github.com/google/go-licenses@v1.6.0
       # Build release artifacts
       - run: mkdir -p ./release_artifacts
       - name: Build driver binaries
@@ -53,16 +65,10 @@ jobs:
               --version "${GITHUB_REF_NAME#v}" \
               --app-version "${GITHUB_REF_NAME}" \
               --destination ./release_artifacts
-      - name: Save licenses
-        run: >
-          go-licenses save ./... --include_tests --force --save_path ./licenses
       - name: Generate licenses.txt
         run: >
-          for FILE_PATH in $(find "./licenses" -type f | LC_ALL=C sort); do \
-            echo -e "${FILE_PATH#./licenses/}:\n" >> ./release_artifacts/licenses.txt \
-            && while read -r LINE; do echo "	$LINE" >> ./release_artifacts/licenses.txt; done < $FILE_PATH \
-            && echo -e "" >> ./release_artifacts/licenses.txt; \
-          done
+          ./tasks/licenses-save.sh
+          && mv licenses.txt ./release_artifacts
       # Release
       - name: Create GitHub release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.task
 /bin
 /dist-pkg
+/licenses.txt
 /node_modules
+/tmp
 /tools
 /vendor

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,6 +98,14 @@ tasks:
     cmd: >
       echo "✅ ALL LICENSES VALID"
 
+  licenses:save:
+    desc: Save third-party licenses to licenses.txt
+    deps:
+      - dependencies:go
+      - dependencies:node
+      - tools:go-licenses
+    cmd: ./tasks/licenses-save.sh
+
   licenses:go:
     run: once
     deps:

--- a/tasks/licenses-save.sh
+++ b/tasks/licenses-save.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Node dependencies
+yarn licenses generate-disclaimer > ./licenses.txt
+
+# Go dependencies
+rm -rf ./tmp/licenses
+mkdir -p ./tmp/licenses
+./tools/go-licenses save ./... --include_tests --force --save_path ./tmp/licenses
+
+for FILE_PATH in $(find "./tmp/licenses" -type f | LC_ALL=C sort); do
+  echo -e "-----\n\nThe following software may be included in this product: $(dirname ${FILE_PATH#./tmp/licenses/}). This software contains the following license and notice below:\n" >> ./licenses.txt \
+  && while read -r LINE; do echo "$LINE" >> ./licenses.txt; done < $FILE_PATH \
+  && echo -e "" >> ./licenses.txt
+done


### PR DESCRIPTION
# Description

* Includes licenses of node dependencies (generated using `yarn licenses generate-disclaimer`) in release licenses.txt
* Also changes generation of Go licenses to match template used by `yarn licenses generate-disclaimer`

## How Has This Been Tested?

https://github.com/LukasK32/docker-machine-driver-pve/releases/tag/v0.2.0-rc2

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
