### PR TITLE
Add whitelisted domains test to cloud credential form

### DIFF
--- a/pkg/pve-node-driver/l10n/en-us.yaml
+++ b/pkg/pve-node-driver/l10n/en-us.yaml
@@ -3,6 +3,11 @@ cluster:
     pve: Proxmox VE
   credential:
     pve:
+      errors:
+        fetchNodeDriver: |
+          Failed to fetch Proxmox VE Node Driver configuration.
+        whitelistedDomains: |
+          Proxmox VE domain is not present in Node Driver's whitelisted domains.
       url:
         label: Proxmox VE URL
         placeholder: https://proxmox.local:8006


### PR DESCRIPTION
# Description

* Follows #22 
* Adds cloud credential form test for domain being present in driver's whitelisted domains

## How Has This Been Tested?

```bash
API=<Rancher Backend URL> yarn dev
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
