### PR TITLE
Add authorization and version test to cloud credential form

### DIFF
--- a/pkg/pve-node-driver/cloud-credential/pve.vue
+++ b/pkg/pve-node-driver/cloud-credential/pve.vue
@@ -72,6 +72,33 @@ export default {
         return false;
       }
 
+      // Proxmox VE version must be 8.x
+      if(!this.value.decodedData.insecureTls) {
+        try {
+          const { data } = await this.$store.dispatch('management/request', {
+            method: 'GET',
+            url: '/meta/proxy/' + this.value.decodedData.url.replace(/^https?:\/\//, '') + '/api2/json/version',
+            headers: {
+              "X-API-Auth-Header": `PVEAPIToken=${this.value.decodedData.tokenId}=${this.value.decodedData.tokenSecret}`,
+            },
+            redirectUnauthorized: false,
+          })
+  
+          if(!data.version.startsWith('8.')) {
+            this.errorLabelKey = 'cluster.credential.pve.errors.unsupportedProxmoxVersion';
+            return false;
+          }
+        } catch(e) {
+          if(e._status == 401) {
+            this.errorLabelKey = 'cluster.credential.pve.errors.fetchProxmoxVersionUnauthorized';
+          } else {
+            this.errorLabelKey = 'cluster.credential.pve.errors.fetchProxmoxVersion';
+          }
+  
+          return false;
+        }
+      }
+
       return true;
     }
   }

--- a/pkg/pve-node-driver/l10n/en-us.yaml
+++ b/pkg/pve-node-driver/l10n/en-us.yaml
@@ -8,13 +8,19 @@ cluster:
           Failed to fetch Proxmox VE Node Driver configuration.
         whitelistedDomains: |
           Proxmox VE domain is not present in Node Driver's whitelisted domains.
+        fetchProxmoxVersion: |
+          Failed to fetch Proxmox VE version.
+        fetchProxmoxVersionUnauthorized: |
+          Failed to fetch Proxmox VE version - Unauthorized.
+        unsupportedProxmoxVersion: |
+          Proxmox VE version is not supported.
       url:
         label: Proxmox VE URL
         placeholder: https://proxmox.local:8006
       insecureTLS:
         label: Disable Proxmox VE TLS certificate verification
         warning: |
-          Disabling Proxmox VE TLS certificate verification is INSECURE, please ensure that you are aware of the associated risks.
+          Disabling Proxmox VE TLS certificate verification is INSECURE, please ensure that you are aware of the associated risks. This will also disable version check and some UI features of the driver.
       tokenID:
         label: Proxmox VE API Token ID
         placeholder: root@pam!rancher


### PR DESCRIPTION
# Description

* Follows #23
* Adds authorization and version test to cloud credential form

## How Has This Been Tested?

```bash
API=<Rancher Backend URL> yarn dev
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
