### PR TITLE
Use hardware device name for network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ You can use [sample Ubuntu Server template](deploy/templates/ubuntu-server) for 
 
 ## Configuration
 
-| Flag                      | Environment variable    | Default value                      | Description                                                                     |
-| ------------------------- | ----------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
-| `--pve-url`               | `PVE_URL`               | N/A (required)                     | Proxmox VE URL (e.g. `https://<PROXMOX VE ADDRESS>:8006`)                       |
-| `--pve-insecure-tls`      | `PVE_INSECURE_TLS`      | `false`                            | Disables Proxmox VE TLS certificate verification                                |
-| `--pve-token-id`          | `PVE_TOKEN_ID`          | N/A (required)                     | Proxmox VE API Token ID (including username and realm, e.g. `root@pam!rancher`) |
-| `--pve-token-secret`      | `PVE_TOKEN_SECRET`      | N/A (required)                     | Proxmox VE API Token secret                                                     |
-| `--pve-resource-pool`     | `PVE_RESOURCE_POOL`     | N/A (required)                     | Proxmox VE Resource Pool name                                                   |
-| `--pve-template`          | `PVE_TEMPLATE`          | N/A (required)                     | ID of the Proxmox VE template                                                   |
-| `--pve-iso-device`        | `PVE_ISO_DEVICE`        | N/A (required)                     | Bus/Device of the CD/DVD Drive to mount cloud-init ISO to (e.g. `scsi1`)        |
-| `--pve-network-interface` | `PVE_NETWORK_INTERFACE` | N/A (required)                     | Network interface to read machine's IP address form                             |
-| `--pve-ssh-user`          | `PVE_SSH_USER`          | `service`                          | Username for the SSH user that will be created via cloud-init                   |
-| `--pve-ssh-port`          | `PVE_SSH_PORT`          | `22`                               | Port to use when connecting to the machine via SSH                              |
+| Flag                      | Environment variable    | Default value                      | Description                                                                         |
+| ------------------------- | ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `--pve-url`               | `PVE_URL`               | N/A (required)                     | Proxmox VE URL (e.g. `https://<PROXMOX VE ADDRESS>:8006`)                           |
+| `--pve-insecure-tls`      | `PVE_INSECURE_TLS`      | `false`                            | Disables Proxmox VE TLS certificate verification                                    |
+| `--pve-token-id`          | `PVE_TOKEN_ID`          | N/A (required)                     | Proxmox VE API Token ID (including username and realm, e.g. `root@pam!rancher`)     |
+| `--pve-token-secret`      | `PVE_TOKEN_SECRET`      | N/A (required)                     | Proxmox VE API Token secret                                                         |
+| `--pve-resource-pool`     | `PVE_RESOURCE_POOL`     | N/A (required)                     | Proxmox VE Resource Pool name                                                       |
+| `--pve-template`          | `PVE_TEMPLATE`          | N/A (required)                     | ID of the Proxmox VE template                                                       |
+| `--pve-iso-device`        | `PVE_ISO_DEVICE`        | N/A (required)                     | Bus/Device of the CD/DVD Drive to mount cloud-init ISO to (e.g. `scsi1`)            |
+| `--pve-network-interface` | `PVE_NETWORK_INTERFACE` | N/A (required)                     | Bus/Device of the network interface to read machine's IP address form (e.g. `net0`) |
+| `--pve-ssh-user`          | `PVE_SSH_USER`          | `service`                          | Username for the SSH user that will be created via cloud-init                       |
+| `--pve-ssh-port`          | `PVE_SSH_PORT`          | `22`                               | Port to use when connecting to the machine via SSH                                  |
 
 ## Contributing
 

--- a/cmd/docker-machine-driver-pve/driver/config.go
+++ b/cmd/docker-machine-driver-pve/driver/config.go
@@ -52,7 +52,7 @@ type config struct {
 	// Bus/Device of the CD/DVD Drive to mount cloud-init ISO to (e.g. 'scsi1').
 	ISODeviceName string
 
-	// Network interface to read machine's IP address form.
+	// Bus/Device of the network interface to read machine's IP address form (e.g. 'net0').
 	NetworkInterfaceName string
 }
 
@@ -97,7 +97,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			Name:   flagNetworkInterface,
 			EnvVar: flagEnvVarFromFlagName(flagNetworkInterface),
-			Usage:  "Network interface to read machine's IP address form",
+			Usage:  "Bus/Device of the network interface to read machine's IP address form (e.g. 'net0')",
 		},
 		mcnflag.StringFlag{
 			Name:   flagSSHUser,

--- a/cmd/docker-machine-driver-pve/driver/util.go
+++ b/cmd/docker-machine-driver-pve/driver/util.go
@@ -1,0 +1,41 @@
+package driver
+
+import (
+	"slices"
+	"strings"
+)
+
+func getMACFromPveNetworkDevice(device string) string {
+	models := []string{
+		"e1000",
+		"e1000-82540em",
+		"e1000-82544gc",
+		"e1000-82545em",
+		"e1000e",
+		"i82551",
+		"i82557b",
+		"i82559er",
+		"ne2k_isa",
+		"ne2k_pci",
+		"pcnet",
+		"rtl8139",
+		"virtio",
+		"vmxnet3",
+	}
+
+	for _, param := range strings.Split(device, ",") {
+		//nolint:mnd
+		values := strings.SplitN(param, "=", 2)
+
+		//nolint:mnd
+		if len(values) != 2 {
+			continue
+		}
+
+		if slices.Contains(models, values[0]) {
+			return values[1]
+		}
+	}
+
+	return ""
+}

--- a/cmd/docker-machine-driver-pve/driver/util_test.go
+++ b/cmd/docker-machine-driver-pve/driver/util_test.go
@@ -1,0 +1,33 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getMACFromPveNetworkDevice(t *testing.T) {
+	tests := map[string]string{
+		"":                                       "",
+		",":                                      "",
+		"bridge=vmbr1":                           "",
+		"e1000=BC:24:11:45:CD:E8,bridge=vmbr0":   "BC:24:11:45:CD:E8",
+		"e1000e=BC:24:11:E1:F0:71,bridge=vmbr3":  "BC:24:11:E1:F0:71",
+		"rtl8139=BC:24:11:18:BB:08,bridge=vmbr1": "BC:24:11:18:BB:08",
+		"virtio=BC:24:11:87:63:EC,bridge=vmbr1":  "BC:24:11:87:63:EC",
+		"vmxnet3=BC:24:11:EB:05:E9,bridge=vmbr4": "BC:24:11:EB:05:E9",
+	}
+
+	for deviceConfiguration, expectedAddress := range tests {
+		t.Run(
+			deviceConfiguration,
+			func(t *testing.T) {
+				require.Equal(
+					t,
+					expectedAddress,
+					getMACFromPveNetworkDevice(deviceConfiguration),
+				)
+			},
+		)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/docker/docker => github.com/moby/moby v1.4.2-0.20170731201646
 require (
 	github.com/luthermonson/go-proxmox v0.2.1
 	github.com/rancher/machine v0.15.0-rancher126
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -14,11 +15,13 @@ require (
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/diskfs/go-diskfs v1.2.0 // indirect
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jinzhu/copier v0.3.4 // indirect
 	github.com/magefile/mage v1.14.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect


### PR DESCRIPTION
# Description

* Flag `--pve-network-interface` now expects hardware device name (e.g. `net0`) instead of OS device name (e.g. `ens18`)
* It removes a bit of guesswork and also allows for a "dropdown" in the Rancher UI Extension

## How Has This Been Tested?

```bash
rancher-machine create -d pve --pve-network-interface net0 test-machine
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
