### PR TITLE
Remove machine on creation failure

### DIFF
--- a/cmd/docker-machine-driver-pve/driver/driver.go
+++ b/cmd/docker-machine-driver-pve/driver/driver.go
@@ -104,6 +104,19 @@ func (d *Driver) Create() error {
 
 	d.PVEMachineID = &vmid
 
+	if err := d.initialize(); err != nil {
+		if removeErr := d.Remove(); removeErr != nil {
+			return fmt.Errorf("failed to initialize the machine: %w; failed to remove uninitialized machine: %w", err, removeErr)
+		}
+
+		return fmt.Errorf("failed to initialize the machine: %w; machine was removed successfully", err)
+	}
+
+	return nil
+}
+
+// Initializes the current machine.
+func (d *Driver) initialize() error {
 	log.Info("Tagging the machine...")
 
 	machine, err := d.getPVEVirtualMachine(context.TODO(), *d.PVEMachineID)


### PR DESCRIPTION
# Description

`PVEMachineID` is not saved if `Driver.Create()` errors, leaving an orphaned VM in Proxmox. To combat that, the machine should be removed before returning from that method.

## How Has This Been Tested?

Tested together with #29 by disconnecting network interface on the template and attempted to create a machine.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
