### PR TITLE
Add scope-enum rule to commitlint

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -16,3 +16,8 @@ rules:
       - build
       # Other changes: bumping dependencies, configuring tools etc.
       - chore
+  scope-enum:
+    - 2
+    - always
+    - - docker-machine-driver
+      - rancher-ui-extension


### PR DESCRIPTION
# Description

Adds `scope-enum` rule to commitlint consistent with our scope labels on GitHub.

## How Has This Been Tested?

`task lint:commits`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
