### PR TITLE
Move advanced fields to "advanced" section

### DIFF
--- a/pkg/pve-node-driver/l10n/en-us.yaml
+++ b/pkg/pve-node-driver/l10n/en-us.yaml
@@ -54,6 +54,7 @@ cluster:
         header: Memory ballooning
         minimumMemory:
           label: Minimum memory (balloon target)
+          tooltip: When set to 0, disables ballooning. When left empty, value from "Memory" is assigned as ballooning target.
       ssh:
         header: SSH Connection
         username:

--- a/pkg/pve-node-driver/l10n/en-us.yaml
+++ b/pkg/pve-node-driver/l10n/en-us.yaml
@@ -30,14 +30,14 @@ cluster:
         placeholder: 00000000-0000-0000-0000-000000000000
   machineConfig:
     pve:
-      resourcePool:
-        label: Name of the Proxmox VE Resource Pool
       template:
-        label: ID of the Proxmox VE Template
-      devices:
-        header: Devices
+        header: Template
+        resourcePool:
+          label: Name of the Proxmox VE Resource Pool
+        templateID:
+          label: ID of the Proxmox VE Template
         iso:
-          label: CD/DVD Drive
+          label: Cloud-init CD/DVD Drive
           tooltip: Bus/Device of the CD/DVD Drive to mount cloud-init ISO to (e.g. `scsi1`)
         network:
           label: Network interface

--- a/pkg/pve-node-driver/l10n/en-us.yaml
+++ b/pkg/pve-node-driver/l10n/en-us.yaml
@@ -50,7 +50,9 @@ cluster:
           label: Processor cores
         memory:
           label: Memory
-        memoryBalloon:
+      memoryBalloon:
+        header: Memory ballooning
+        minimumMemory:
           label: Minimum memory (balloon target)
       ssh:
         header: SSH Connection

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -452,10 +452,10 @@ export default {
       required
     />
 
-    <h2 class="mt-20">
+    <h3 class="mt-20">
       <t k="cluster.machineConfig.pve.devices.header" />
-    </h2>
-    <div class="row mt-20">
+    </h3>
+    <div class="row mb-20">
       <div class="col span-6">
         <!-- ISO Device -->
         <LabeledInput
@@ -507,10 +507,10 @@ export default {
       </div>
     </div>
 
-    <h2 class="mt-20">
+    <h3>
       <t k="cluster.machineConfig.pve.hardware.header" />
-    </h2>
-    <div class="row mt-20">
+    </h3>
+    <div class="row mb-10">
       <div class="col span-6">
         <!-- Processor sockets -->
         <UnitInput
@@ -537,7 +537,7 @@ export default {
       </div>
     </div>
 
-    <div class="row mt-20">
+    <div class="row mb-20">
       <div class="col span-6">
         <!-- Memory -->
         <UnitInput
@@ -567,10 +567,10 @@ export default {
       </div>
     </div>
 
-    <h2 class="mt-20">
+    <h3>
       <t k="cluster.machineConfig.pve.ssh.header" />
-    </h2>
-    <div class="row mt-20">
+    </h3>
+    <div class="row mb-20">
       <div class="col span-6">
         <!-- SSH Username -->
         <LabeledInput
@@ -596,6 +596,5 @@ export default {
         />
       </div>
     </div>
-
   </div>
 </template>

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -84,6 +84,15 @@ export default {
         this.fetchHardware(),
       ]);
     },
+    'currentValue.memory': function(newValue, oldValue) {
+      if(this.currentValue.memoryBalloon == 0) {
+        return
+      }
+
+      if(oldValue == this.currentValue.memoryBalloon || newValue < this.currentValue.memoryBalloon) {
+        this.currentValue.memoryBalloon = newValue;
+      }
+    },
     currentValue: {
       deep: true,
       handler(){
@@ -595,7 +604,6 @@ export default {
           v-model:value="currentValue.memory"
           label-key="cluster.machineConfig.pve.hardware.memory.label"
           suffix="MiB"
-          :status="currentValue.memory != '' && currentValue.memoryBalloon != '' && currentValue.memoryBalloon > currentValue.memory ? 'error' : undefined"
           min="0"
           step="256"
         />
@@ -609,7 +617,6 @@ export default {
           v-model:value="currentValue.memoryBalloon"
           label-key="cluster.machineConfig.pve.hardware.memoryBalloon.label"
           suffix="MiB"
-          :status="currentValue.memory != '' && currentValue.memoryBalloon != '' && currentValue.memoryBalloon > currentValue.memory ? 'error' : undefined"
           min="0"
           step="256"
           :max="currentValue.memory != '' ? currentValue.memory : undefined"

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -372,7 +372,8 @@ export default {
         this.currentValue.processorSockets = data.sockets;
         this.currentValue.processorCores = data.cores;
         this.currentValue.memory = data.memory;
-        this.currentValue.memoryBalloon = data.balloon ?? data.memory;
+        // Memory balloon is an advanced (hidden by default) field, so we default to using the memory value so it is synced unless set explicitly to a different value.
+        this.currentValue.memoryBalloon = data.memory;
       } catch(e) {
         this.currentValue.processorSockets = "";
         this.currentValue.processorCores = "";
@@ -608,23 +609,29 @@ export default {
           step="256"
         />
       </div>
-      <div class="col span-6">
-        <!-- Memory balloon -->
-        <UnitInput
-          type="number"
-          :mode="mode"
-          :disabled="disabled || (templates != null && !currentValue.template)"
-          v-model:value="currentValue.memoryBalloon"
-          label-key="cluster.machineConfig.pve.hardware.memoryBalloon.label"
-          suffix="MiB"
-          min="0"
-          step="256"
-          :max="currentValue.memory != '' ? currentValue.memory : undefined"
-        />
-      </div>
     </div>
 
     <portal :to="`advanced-${uuid}`">
+      <h3>
+        <t k="cluster.machineConfig.pve.memoryBalloon.header" />
+      </h3>
+      <div class="row mb-20">
+        <div class="col span-6">
+          <!-- Memory balloon -->
+          <UnitInput
+            type="number"
+            :mode="mode"
+            :disabled="disabled || (templates != null && !currentValue.template)"
+            v-model:value="currentValue.memoryBalloon"
+            label-key="cluster.machineConfig.pve.memoryBalloon.minimumMemory.label"
+            suffix="MiB"
+            min="0"
+            step="256"
+            :max="currentValue.memory != '' ? currentValue.memory : undefined"
+          />
+        </div>
+      </div>
+
       <h3>
         <t k="cluster.machineConfig.pve.ssh.header" />
       </h3>

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -624,6 +624,7 @@ export default {
             :disabled="disabled || (templates != null && !currentValue.template)"
             v-model:value="currentValue.memoryBalloon"
             label-key="cluster.machineConfig.pve.memoryBalloon.minimumMemory.label"
+            tooltip-key="cluster.machineConfig.pve.memoryBalloon.minimumMemory.tooltip"
             suffix="MiB"
             min="0"
             step="256"

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -407,58 +407,60 @@ export default {
 
 <template>
   <div class="mt-20 mb-20">
-    <!-- Resource pool  -->
-    <LabeledInput
-      v-if="resourcePools == null"
-      type="text"
-      :mode="mode"
-      :disabled="disabled"
-      :value="currentValue.resourcePool"
-      @change="e => { currentValue.resourcePool = e.target.value}"
-      label-key="cluster.machineConfig.pve.resourcePool.label"
-      required
-    />
-
-    <LabeledSelect
-      v-else
-      :mode="mode"
-      :disabled="disabled"
-      v-model:value="currentValue.resourcePool"
-      :options="resourcePools"
-      label-key="cluster.machineConfig.pve.resourcePool.label"
-      required
-    />
-
-    <!-- Template -->
-    <LabeledInput
-      v-if="templates == null"
-      class="mt-20"
-      type="number"
-      :mode="mode"
-      :disabled="disabled"
-      :value="currentValue.template"
-      @change="e => { currentValue.template = e.target.value}"
-      label-key="cluster.machineConfig.pve.template.label"
-      required
-      min="1"
-      step="1"
-    />
-
-    <LabeledSelect
-      v-else
-      class="mt-20"
-      :mode="mode"
-      :disabled="disabled || (resourcePools != null && !currentValue.resourcePool)"
-      v-model:value="templateSelectValue"
-      @option:selected="selectTemplate"
-      :options="Object.values(templateSelectOptions)"
-      label-key="cluster.machineConfig.pve.template.label"
-      required
-    />
-
-    <h3 class="mt-20">
-      <t k="cluster.machineConfig.pve.devices.header" />
+    <h3>
+      <t k="cluster.machineConfig.pve.template.header" />
     </h3>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <!-- Resource pool  -->
+        <LabeledInput
+          v-if="resourcePools == null"
+          type="text"
+          :mode="mode"
+          :disabled="disabled"
+          :value="currentValue.resourcePool"
+          @change="e => { currentValue.resourcePool = e.target.value}"
+          label-key="cluster.machineConfig.pve.template.resourcePool.label"
+          required
+        />
+
+        <LabeledSelect
+          v-else
+          :mode="mode"
+          :disabled="disabled"
+          v-model:value="currentValue.resourcePool"
+          :options="resourcePools"
+          label-key="cluster.machineConfig.pve.template.resourcePool.label"
+          required
+        />
+      </div>
+      <div class="col span-6">
+        <!-- Template -->
+        <LabeledInput
+          v-if="templates == null"
+          type="number"
+          :mode="mode"
+          :disabled="disabled"
+          :value="currentValue.template"
+          @change="e => { currentValue.template = e.target.value}"
+          label-key="cluster.machineConfig.pve.template.templateID.label"
+          required
+          min="1"
+          step="1"
+        />
+
+        <LabeledSelect
+          v-else
+          :mode="mode"
+          :disabled="disabled || (resourcePools != null && !currentValue.resourcePool)"
+          v-model:value="templateSelectValue"
+          @option:selected="selectTemplate"
+          :options="Object.values(templateSelectOptions)"
+          label-key="cluster.machineConfig.pve.template.templateID.label"
+          required
+        />
+      </div>
+    </div>
     <div class="row mb-20">
       <div class="col span-6">
         <!-- ISO Device -->
@@ -469,8 +471,8 @@ export default {
           :disabled="disabled"
           :value="currentValue.isoDevice"
           @change="e => { currentValue.isoDevice = e.target.value}"
-          label-key="cluster.machineConfig.pve.devices.iso.label"
-          tooltip-key="cluster.machineConfig.pve.devices.iso.tooltip"
+          label-key="cluster.machineConfig.pve.template.iso.label"
+          tooltip-key="cluster.machineConfig.pve.template.iso.tooltip"
           required
         />
 
@@ -480,8 +482,8 @@ export default {
           :disabled="disabled || (templates != null && !currentValue.template)"
           v-model:value="currentValue.isoDevice"
           :options="isoDeviceSelectOptions"
-          label-key="cluster.machineConfig.pve.devices.iso.label"
-          tooltip-key="cluster.machineConfig.pve.devices.iso.tooltip"
+          label-key="cluster.machineConfig.pve.template.iso.label"
+          tooltip-key="cluster.machineConfig.pve.template.iso.tooltip"
           required
         />
       </div>
@@ -493,8 +495,8 @@ export default {
           :mode="mode"
           :value="currentValue.networkInterface"
           @change="e => { currentValue.networkInterface = e.target.value}"
-          label-key="cluster.machineConfig.pve.devices.network.label"
-          tooltip-key="cluster.machineConfig.pve.devices.network.tooltip"
+          label-key="cluster.machineConfig.pve.template.network.label"
+          tooltip-key="cluster.machineConfig.pve.template.network.tooltip"
           required
         />
 
@@ -504,8 +506,8 @@ export default {
           :disabled="disabled || (templates != null && !currentValue.template)"
           v-model:value="currentValue.networkInterface"
           :options="networkInterfaceSelectOptions"
-          label-key="cluster.machineConfig.pve.devices.network.label"
-          tooltip-key="cluster.machineConfig.pve.devices.network.tooltip"
+          label-key="cluster.machineConfig.pve.template.network.label"
+          tooltip-key="cluster.machineConfig.pve.template.network.tooltip"
           required
         />
       </div>

--- a/pkg/pve-node-driver/machine-config/pve.vue
+++ b/pkg/pve-node-driver/machine-config/pve.vue
@@ -11,6 +11,10 @@ export default {
     UnitInput,
   },
   props: {
+    uuid: {
+      type:     String,
+      required: true,
+    },
     mode: {
       type:     String,
       required: true,
@@ -567,34 +571,36 @@ export default {
       </div>
     </div>
 
-    <h3>
-      <t k="cluster.machineConfig.pve.ssh.header" />
-    </h3>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <!-- SSH Username -->
-        <LabeledInput
-          type="text"
-          :mode="mode"
-          v-model:value="currentValue.sshUser"
-          label-key="cluster.machineConfig.pve.ssh.username.label"
-          tooltip-key="cluster.machineConfig.pve.ssh.username.tooltip"
-          required
-        />
+    <portal :to="`advanced-${uuid}`">
+      <h3>
+        <t k="cluster.machineConfig.pve.ssh.header" />
+      </h3>
+      <div class="row">
+        <div class="col span-6">
+          <!-- SSH Username -->
+          <LabeledInput
+            type="text"
+            :mode="mode"
+            v-model:value="currentValue.sshUser"
+            label-key="cluster.machineConfig.pve.ssh.username.label"
+            tooltip-key="cluster.machineConfig.pve.ssh.username.tooltip"
+            required
+          />
+        </div>
+        <div class="col span-6">
+          <!-- SSH Port -->
+          <LabeledInput
+            type="number"
+            :mode="mode"
+            v-model:value="currentValue.sshPort"
+            label-key="cluster.machineConfig.pve.ssh.port.label"
+            tooltip-key="cluster.machineConfig.pve.ssh.port.tooltip"
+            required
+            min="1"
+            step="1"
+          />
+        </div>
       </div>
-      <div class="col span-6">
-        <!-- SSH Port -->
-        <LabeledInput
-          type="number"
-          :mode="mode"
-          v-model:value="currentValue.sshPort"
-          label-key="cluster.machineConfig.pve.ssh.port.label"
-          tooltip-key="cluster.machineConfig.pve.ssh.port.tooltip"
-          required
-          min="1"
-          step="1"
-        />
-      </div>
-    </div>
+    </portal>
   </div>
 </template>


### PR DESCRIPTION
# Description

Moves advanced fields to the "advanced" section on the machine pool configuration screen. Also makes UI (margins, headers) more consistent with Rancher styles.

## How Has This Been Tested?

### Normal view
<img width="800" alt="image" src="https://github.com/user-attachments/assets/39a9a1c9-51d6-495a-a135-836c8acac0d8" />


### Normal view for cloud credential with insecure TLS enabled
<img width="800" alt="image" src="https://github.com/user-attachments/assets/cf2af52f-9d75-431c-a46e-358faedbf216" />


### Advanced view
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f62d76bc-3513-45ab-968f-2e7f93c97543" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
