### PR TITLE
fix: set ip address in driver struct

### DIFF
--- a/cmd/docker-machine-driver-pve/driver/driver.go
+++ b/cmd/docker-machine-driver-pve/driver/driver.go
@@ -287,11 +287,15 @@ func (d *Driver) GetIP() (string, error) {
 
 	if len(possibleIPv4s) > 0 {
 		slices.Sort(possibleIPv4s)
+		d.IPAddress = possibleIPv4s[0]
+
 		return possibleIPv4s[0], nil
 	}
 
 	if len(possibleIPv6s) > 0 {
 		slices.Sort(possibleIPv6s)
+		d.IPv6Address = possibleIPv6s[0]
+
 		return possibleIPv6s[0], nil
 	}
 


### PR DESCRIPTION
# Description

At the moment, it is not possible to SSH to a VM created by the pve driver directly from Rancher Web Interface. See #62.
This pull request fixes this bug by setting the IPAddress or IPv6Address in the driver struct when calling GetIP().

This will set the IP address in the secret Rancher populates after the VM is provisioned.

## How Has This Been Tested?

I tested this manually against a proxmox cluster.
I just replaced the binary on an already deployed driver and I was able to SSH to a VM.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
